### PR TITLE
frog-fifo-v1: distill progress guarantees in set_barrier

### DIFF
--- a/frog-protocols/frog-fifo-v1.xml
+++ b/frog-protocols/frog-fifo-v1.xml
@@ -92,8 +92,7 @@
         it sets a "fifo_barrier" condition on the surface associated with
         the fifo object. The condition is cleared immediately after the
         following latching deadline for non-tearing presentation.
-        If the surface is not currently being presented by the compositor,
-        the condition needs to be cleared soon enough so that forward
+        The condition needs to be cleared soon enough so that forward
         progress for the application is guaranteed. The exact rate at which
         that happens is implementation defined.
 


### PR DESCRIPTION
It is not clear what it means for a surface to be being presented. For example, consider a visible surface that is partially on screen and partially off screen. It is not unreasonable to say that such a surface is being presented. But if the content update only damages a region that is off screen, then the latching deadline is unlikely to occur soon and the surface might in fact dead lock itself.

Instead of trying to define what _being presented_ means in this context, reword to get closer to the goal of the sentence.

In practice, on a regular monitor (VRR or otherwise), compositors are more likely to schedule a latching deadline unconditionally if a content update contains a set_barrier request. But the protocol does not need to concern itself with this.

![image](https://github.com/user-attachments/assets/7c974699-0c48-4f24-a6fd-680c6ffe606f)
